### PR TITLE
ラベルで検索できる機能の追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,15 @@ script/tex
 script/user
 script/remove
 
+script/cron/update_sequence
+
 config/configure.ml
 
 static/tosho.tex
+
+*.cmi
+*.o
+*.cmx
+*.opt
+.omakedb*
+*.omc

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ This is a bibliography managing tool.
 
 ## Requirements
 
-* OCaml (4.00.1 or later) and the following libraries
+* OCaml (4.00.1 or later) and the following libraries **Recommend 4.05 < version < 4.08.0**
   * batteries
-  * pgocaml
-  * pgocaml.syntax
+  * pgocaml **Recommend 3.2**
+  * pgocaml.syntax **Recommend 3.2**
   * cryptokit
   * yojson
   * config-file

--- a/api/search.ml
+++ b/api/search.ml
@@ -36,7 +36,7 @@ let query (cgi: Netcgi.cgi) query =
   let queries =
     BatList.sort_unique
       String.compare
-      (BatString.nsplit query " ")
+      (BatString.split_on_string " " query)
   in
   redirect_to_script
     cgi

--- a/script/model.ml
+++ b/script/model.ml
@@ -183,7 +183,7 @@ let find_or_insert_author dbh author =
 ;;
 
 let authors_of_string authors =
-  let authors = List.map BatString.trim (BatString.nsplit authors ",") in
+  let authors = List.map BatString.trim (BatString.split_on_string "," authors) in
   if BatList.is_empty authors || List.exists BatString.is_empty authors then
     None
   else

--- a/script/model.ml
+++ b/script/model.ml
@@ -245,3 +245,40 @@ let start_date_of_lending (_, _, sdate, _) = sdate
 ;;
 let due_date_of_lending (_, _, _, ddate) = ddate
 ;;
+
+(** book_with_entry **)
+
+type book_with_entry =
+  int32 *    (* book id *)
+  string *   (* ISBN *)
+  string *   (* location *)
+  string *   (* kind *)
+  string *   (* label *)
+  string *   (* status *)
+  CalendarLib.Date.t *      (* register_date *)
+  CalendarLib.Date.t option * (* purchase_date *)
+  string *   (* title *)
+  int32 *    (* publish year *)
+  int32      (* publisher id *)
+;;
+
+let id_of_book_with_entry ((id, _, _, _, _, _, _, _, _, _, _) : book_with_entry) = id
+;;
+let isbn_of_book_with_entry ((_, isbn, _, _, _, _, _, _, _, _, _) : book_with_entry) = isbn
+;;
+let location_of_book_with_entry ((_, _, loc, _, _, _, _, _, _, _, _) : book_with_entry) = loc
+;;
+let kind_of_book_with_entry ((_, _, _, kind, _, _, _, _, _, _, _) : book_with_entry) = kind
+;;
+let label_of_book_with_entry ((_, _, _, _, label, _, _, _, _, _, _) : book_with_entry) = label
+;;    
+let status_of_book_with_entry ((_, _, _, _, _, status, _, _, _, _, _) : book_with_entry) = status
+;;
+let title_of_book_with_entry ((_, _, _, _, _, _, _, _, title, _, _) : book_with_entry) = title
+;;
+let publisher_id_of_book_with_entry ((_, _, _, _, _, _, _, _, _, _, publisher_id) : book_with_entry) = publisher_id
+;;
+let book_of_book_with_entry ((id, isbn, loc, kind, label, status, register_date, purchase_date, _, _, _) : book_with_entry) = (id, isbn, loc, kind, label, status, register_date, purchase_date)
+;;
+let entry_of_book_with_entry ((_, isbn, _, _, _, _, _, _, title, publish_year, publisher_id) : book_with_entry) = (isbn, title, publish_year, publisher_id)
+;;


### PR DESCRIPTION
# 変更点
- コンパイルが通らないdeprecatedを直す
  - `BatString.nsplit` を`BatString.split_on_string` へ

- READMEの依存関係の訂正
  - `pgocaml` が4系列でおそらく破壊的な変更を行っている臭い
  - `pgocaml.syntax` が入らない

- `book_with_entry`モデルの追加
  - `book`のisbnをキーとして、`entry`情報をjoinしたモデルの追加

- 検索のロジックを変更
  - 従来は`entry`テーブルをfilterし、対応するisbnの`book`を結果として返す仕組みだった
  - `entry`テーブル以外の要素(`book.label`)で検索を行うため、`book_with_entry`を使ってfilterする
  - なるべく既存のコードを変更しないために、`jsonify`メソッドに引数を無理やりそろえている

# 既知の問題
- そもそもアプリレイヤーで検索したくない
  - といっても、高々2000件行かないのでこれでも十分という話がある
  - 何かしらの検索アルゴリズム(Elastic Search的な)を導入するか、SQLでキャッシュをかけて全文検索が丸そう
  - 今回の工数では無視