### PR TITLE
shift_jisでの出力に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This is a bibliography managing tool.
   * netstring
   * netcgi2
   * pcre
+  * text
 * OMake
 * PostgreSQL
 

--- a/js/app.js
+++ b/js/app.js
@@ -1510,7 +1510,7 @@ Bibman.switch_tab = function(id) {
 
 /* swtich contents */
 Bibman.download_csv = function () {
-  var url = Bibman.API.ROOT + '/download_csv.cgi';
+  var url = Bibman.API.ROOT + 'download_csv.cgi';
 
   $.fileDownload(url, {
     failCallback: function() {

--- a/script/OMakefile
+++ b/script/OMakefile
@@ -12,6 +12,7 @@ OCAMLPACKS[] =
 	config-file
 	netstring
 	pcre
+	text
 
 OCAMLINCLUDES += ../lib
 

--- a/script/download_csv.ml
+++ b/script/download_csv.ml
@@ -12,13 +12,13 @@ let list dbh _ =
   in
   let dq = "\"" in
   let concat_symbol = "\",\"" in
-  Some (`Stringlit
-    (List.fold_left
+  let csv_str = (List.fold_left
     (fun a b -> a ^ b)
     (dq ^ "title" ^ concat_symbol ^ "location" ^ concat_symbol ^ "kind"
-     ^ concat_symbol ^ "status" ^ concat_symbol ^ "label" ^ concat_symbol ^ "isbn" ^ concat_symbol ^ "account" ^ "\"\n")
+    ^ concat_symbol ^ "status" ^ concat_symbol ^ "label" ^ concat_symbol ^ "isbn" ^ concat_symbol ^ "account" ^ "\"\n")
     (List.map (fun bd -> csv_of_book_detail bd) lists))
-  )
+  in
+  (Some (`Stringlit (Encoding.recode_string "UTF8" "Shift_JIS" csv_str)))
 ;;
 
 let actions = [


### PR DESCRIPTION
Microsoft Excelがcsvを開くとき、デフォルトでshift_jisで読もうとする。この挙動に合わせ、utf-8で出力していたところをshift_jisに変更。